### PR TITLE
Wrap Jan's Schema.org microdata library & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-node-metadata
+html-metadata
 =============
+
+# MetaData html scraper and parser for Node.js
+
+The aim of this library is to be a comprehensive source for extracting all html embedded metadata. Currently it supports Open Graph and Schema.org microdata using third party libraries, and a native Dublin Core implementation.
+
+Planned is support for twitter, AGLS, eprints, highwire, BEPress and other yet unheard of metadata types. Contributions and requests for other metadata types welcome!
+
+Longterm goals include support for linked-to embedded RDF.
+
+## Install
+
+	npm install git://github.com/mvolz/html-metadata.git
+
+## Usage
+
+```js
+var scrape = require('html-metadata');
+
+var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
+
+scrape(url, function(err, meta){
+	console.log(meta);
+})
+```
+
+The scrape method used here invokes the parseAll() method, which uses all the available methods registered in method metadataFunctions, and are available for use separately as well, for example:
+
+```js
+var cheerio = require('cheerio');
+var request = require('request');
+var dublinCore = require('html-metadata').parseDublinCore;
+
+var url = "http://blog.woorank.com/2013/04/dublin-core-metadata-for-seo-and-usability/";
+
+request(url, function(error, response, html){
+	$ = cheerio.load(html);
+	dublinCore($, function(err, results){
+		callback(err, results);
+	});
+});
+```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"async": "0.9.0",
 		"cheerio" : "0.18.0",
+		"microdata-node" : "0.1.2",
 		"open-graph" : "git://github.com/mvolz/node-open-graph.git",
 		"request" : "2.49.0"
 	},


### PR DESCRIPTION
* Add wrapper around microdata-node library.
* Fix bug in scrapeDublinCore which used the Cheerio instance
in memory rather the one passed through callback.
* Remove unwritten methods.
* Fill out readme file.